### PR TITLE
fix: reject non-finite and out-of-range ttl/tti values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 ahash = "0.8.12"
 pyo3 = "0.29.2"
-moka = {
+moka = { 
     version = "0.12.15",
     features = ["sync"],
 }
@@ -43,6 +43,82 @@ version = "=0.1.52"
 features = [
     "win_direct_tls",
 ]
+
+[lints.rust]
+warnings = "deny"
+
+[lints.clippy]
+# Groups
+all = "deny"
+pedantic = "deny"
+
+# Panics and unwinding
+panic = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+unimplemented = "deny"
+unreachable = "deny"
+dbg_macro = "deny"
+todo = "deny"
+
+# Indexing
+indexing_slicing = "deny"
+
+# Casts
+cast_possible_truncation = "deny"
+cast_possible_wrap = "deny"
+cast_precision_loss = "deny"
+cast_sign_loss = "deny"
+cast_lossless = "deny"
+
+# From/Into
+fallible_impl_from = "deny"
+
+# Pattern matching
+match_same_arms = "deny"
+match_wildcard_for_single_variants = "deny"
+wildcard_enum_match_arm = "deny"
+
+# Control flow
+if_not_else = "deny"
+needless_continue = "deny"
+
+# Loops
+explicit_iter_loop = "deny"
+explicit_into_iter_loop = "deny"
+
+# Cloning
+redundant_clone = "deny"
+implicit_clone = "deny"
+clone_on_copy = "deny"
+
+# Unsafe
+undocumented_unsafe_blocks = "deny"
+
+# Strings
+str_to_string = "deny"
+string_add = "deny"
+string_lit_as_bytes = "deny"
+
+# Collections
+get_unwrap = "deny"
+
+# Functions
+fn_params_excessive_bools = "deny"
+must_use_candidate = "deny"
+unnecessary_wraps = "deny"
+
+# Error handling
+map_err_ignore = "deny"
+
+# Memory / allocations
+large_stack_arrays = "deny"
+rc_buffer = "deny"
+
+# Misc
+print_stdout = "deny"
+print_stderr = "deny"
+use_debug = "deny"
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ mod moka_py {
     impl Hash for AnyKey {
         #[inline]
         fn hash<H: Hasher>(&self, state: &mut H) {
-            state.write_isize(self.py_hash)
+            state.write_isize(self.py_hash);
         }
     }
 
@@ -91,18 +91,22 @@ mod moka_py {
         }
     }
 
+    /// Convert a number of seconds coming from Python into a `Duration`.
+    ///
+    /// Rejects zero, negative, NaN and infinite values explicitly instead of
+    /// relying on the saturating behaviour of a `f64 as u64` cast, which
+    /// silently turned an absurd value such as `1e30` into a ~584942 year TTL.
     #[inline]
     fn parse_duration(value: Option<f64>, name: &str) -> PyResult<Option<Duration>> {
-        match value {
-            Some(v) => {
-                let micros = (v * 1_000_000.0) as u64;
-                if micros == 0 {
-                    return Err(PyValueError::new_err(format!("{name} must be positive")));
-                }
-                Ok(Some(Duration::from_micros(micros)))
-            }
-            None => Ok(None),
+        let Some(seconds) = value else {
+            return Ok(None);
+        };
+        if !seconds.is_finite() || seconds <= 0.0 {
+            return Err(PyValueError::new_err(format!("{name} must be positive")));
         }
+        let duration = Duration::try_from_secs_f64(seconds)
+            .map_err(|e| PyValueError::new_err(format!("{name} is out of range: {e}")))?;
+        Ok(Some(duration))
     }
 
     #[derive(Clone)]
@@ -190,20 +194,12 @@ mod moka_py {
                 .expire_after(PerEntryExpiry)
                 .eviction_policy(policy.into());
 
-            if let Some(ttl) = ttl {
-                let ttl_micros = (ttl * 1_000_000.0) as u64;
-                if ttl_micros == 0 {
-                    return Err(PyValueError::new_err("ttl must be positive"));
-                }
-                builder = builder.time_to_live(Duration::from_micros(ttl_micros));
+            if let Some(time_to_live) = parse_duration(ttl, "ttl")? {
+                builder = builder.time_to_live(time_to_live);
             }
 
-            if let Some(tti) = tti {
-                let tti_micros = (tti * 1_000_000.0) as u64;
-                if tti_micros == 0 {
-                    return Err(PyValueError::new_err("tti must be positive"));
-                }
-                builder = builder.time_to_idle(Duration::from_micros(tti_micros));
+            if let Some(time_to_idle) = parse_duration(tti, "tti")? {
+                builder = builder.time_to_idle(time_to_idle);
             }
 
             if let Some(listener) = eviction_listener {
@@ -212,7 +208,7 @@ mod moka_py {
                         let key = k.as_ref().obj.clone_ref(py);
                         let value = v.value.as_ref().clone_ref(py);
                         if let Err(e) = listener.call1(py, (key, value, cause_to_str(cause))) {
-                            e.restore(py)
+                            e.restore(py);
                         }
                     });
                 };
@@ -225,11 +221,8 @@ mod moka_py {
         }
 
         #[classmethod]
-        fn __class_getitem__(
-            cls: &Bound<'_, PyType>,
-            _key: &Bound<'_, PyAny>,
-        ) -> PyResult<Py<PyAny>> {
-            Ok(cls.clone().into_any().unbind())
+        fn __class_getitem__(cls: &Bound<'_, PyType>, _key: &Bound<'_, PyAny>) -> Py<PyAny> {
+            cls.clone().into_any().unbind()
         }
 
         #[pyo3(signature = (key, value, ttl=None, tti=None))]
@@ -242,12 +235,12 @@ mod moka_py {
             tti: Option<f64>,
         ) -> PyResult<()> {
             let hashable_key = AnyKey::new_with_gil(key, py)?;
-            let per_entry_ttl = parse_duration(ttl, "ttl")?;
-            let per_entry_tti = parse_duration(tti, "tti")?;
+            let time_to_live = parse_duration(ttl, "ttl")?;
+            let time_to_idle = parse_duration(tti, "tti")?;
             let wrapper = ValueWrapper {
                 value: Arc::new(value),
-                per_entry_ttl,
-                per_entry_tti,
+                per_entry_ttl: time_to_live,
+                per_entry_tti: time_to_idle,
                 created_at: Instant::now(),
             };
             self.0.insert(hashable_key, wrapper);
@@ -278,15 +271,15 @@ mod moka_py {
             tti: Option<f64>,
         ) -> PyResult<Py<PyAny>> {
             let hashable_key = AnyKey::new_with_gil(key, py)?;
-            let per_entry_ttl = parse_duration(ttl, "ttl")?;
-            let per_entry_tti = parse_duration(tti, "tti")?;
+            let time_to_live = parse_duration(ttl, "ttl")?;
+            let time_to_idle = parse_duration(tti, "tti")?;
             py.detach(|| {
-                self.0.try_get_with(hashable_key, || {
+                self.0.try_get_with(hashable_key, move || {
                     Python::attach(|py| {
                         initializer.call0(py).map(|v| ValueWrapper {
                             value: Arc::new(v),
-                            per_entry_ttl,
-                            per_entry_tti,
+                            per_entry_ttl: time_to_live,
+                            per_entry_tti: time_to_idle,
                             created_at: Instant::now(),
                         })
                     })

--- a/tests/test_moka.py
+++ b/tests/test_moka.py
@@ -14,7 +14,10 @@ async def test_tti():
     moka.set("hello", value)
     assert moka.get("hello") is value
     assert moka.get("hello") is value
-    await asyncio.sleep(0.2)
+    # Sleep past the TTI rather than exactly up to it: asyncio.sleep only
+    # guarantees a lower bound, and a loaded runner can observe the entry
+    # a hair before it goes idle.
+    await asyncio.sleep(0.3)
     assert moka.get("hello") is None
 
 

--- a/tests/test_moka.py
+++ b/tests/test_moka.py
@@ -43,11 +43,18 @@ def test_eviction():
     for key in keys:
         moka.set(key, key)
 
-    got = []
-    for key in keys:
-        v = moka.get(key)
-        if v is not None:
-            got.append(v)
+    # moka evicts asynchronously: writes go through an internal buffer, so the
+    # cache can transiently hold more than max_capacity. Reads drive that
+    # maintenance, so poll until the count converges instead of racing it.
+    deadline = monotonic() + 5.0
+    while True:
+        got = []
+        for key in keys:
+            v = moka.get(key)
+            if v is not None:
+                got.append(v)
+        if len(got) == size or monotonic() > deadline:
+            break
 
     assert len(got) == size
 

--- a/tests/test_per_entry_expiry.py
+++ b/tests/test_per_entry_expiry.py
@@ -325,3 +325,64 @@ def test_eviction_listener_with_per_entry_ttl():
     assert cache.get("k") is None
 
     assert any(k == "k" and v == "v" for k, v, _ in evicted)
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs", "match"),
+    [
+        ("set", {"ttl": float("inf")}, "ttl must be positive"),
+        ("set", {"tti": float("inf")}, "tti must be positive"),
+        ("set", {"ttl": float("nan")}, "ttl must be positive"),
+        ("set", {"tti": float("nan")}, "tti must be positive"),
+        ("set", {"ttl": 1e30}, "ttl is out of range"),
+        ("get_with", {"ttl": float("inf")}, "ttl must be positive"),
+        ("get_with", {"tti": float("nan")}, "tti must be positive"),
+        ("get_with", {"ttl": 1e30}, "ttl is out of range"),
+    ],
+    ids=[
+        "set_ttl_inf",
+        "set_tti_inf",
+        "set_ttl_nan",
+        "set_tti_nan",
+        "set_ttl_overflow",
+        "get_with_ttl_inf",
+        "get_with_tti_nan",
+        "get_with_ttl_overflow",
+    ],
+)
+def test_non_finite_per_entry_duration(method, kwargs, match):
+    """Non-finite and absurdly large durations are rejected.
+
+    Previously these were silently accepted: the `f64 as u64` cast saturated,
+    so `inf` became a ~584942 year TTL instead of an error.
+    """
+    cache = moka_py.Moka(128)
+    with pytest.raises(ValueError, match=match):
+        if method == "set":
+            cache.set("k", "v", **kwargs)
+        else:
+            cache.get_with("k", lambda: "v", **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"ttl": float("inf")}, "ttl must be positive"),
+        ({"tti": float("nan")}, "tti must be positive"),
+        ({"ttl": 1e30}, "ttl is out of range"),
+    ],
+    ids=["ctor_ttl_inf", "ctor_tti_nan", "ctor_ttl_overflow"],
+)
+def test_non_finite_cache_wide_duration(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        moka_py.Moka(128, **kwargs)
+
+
+def test_class_getitem_returns_the_class():
+    """`Moka[K, V]` is usable as a type annotation and yields the class itself."""
+    assert moka_py.Moka[str, int] is moka_py.Moka
+    assert moka_py.Moka.__class_getitem__(int) is moka_py.Moka
+
+    cache = moka_py.Moka[str, int](128)
+    cache.set("k", 1)
+    assert cache.get("k") == 1


### PR DESCRIPTION
First of four split out of #18. **Independent — safe to merge on its own.**

## The bug

`parse_duration` converted seconds to microseconds with `(v * 1e6) as u64`.
Float-to-int casts saturate in Rust, so out-of-range input was silently
accepted rather than rejected:

```python
Moka(8, ttl=float("inf"))   # -> a TTL of ~584942 years
Moka(8, ttl=1e30)           # -> a TTL of ~584942 years
```

Both now raise `ValueError`. Zero and negative values keep their existing
`"<name> must be positive"` message, so the documented contract is unchanged
and the pre-existing validation tests pass untouched. `Moka::new` now reuses
`parse_duration` instead of duplicating the conversion inline.

**Behaviour change:** `inf` / `NaN` / absurdly large durations used to be
accepted and now raise. Sub-microsecond durations used to be rejected (they
truncated to zero) and are now accepted.

## How it was found

A strict `[lints]` table in `Cargo.toml` (`clippy::pedantic` plus the cast,
panic and indexing lints). All 12 findings are fixed in the code, none
allow-listed:

- explicit duration validation instead of a saturating cast
- `__class_getitem__` no longer wraps an infallible value in `PyResult` —
  verified to be a plain `classmethod_descriptor`, not a pyo3 type slot, so
  dropping the wrapper cannot change the Python-visible protocol
- the `try_get_with` closure consumes its initializer
- missing semicolons, overly similar local bindings

No CI change is needed: the existing `cargo clippy` job and the `just
lint-rust` recipe both pick up the lint table automatically.

## Verified locally

- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- 97 tests pass (85 before; 12 added for the edge cases and `Moka[K, V]`)