### PR TITLE
ci: add supply-chain auditing and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+
+updates:
+  # Rust dependencies (pyo3, moka, mimalloc, ...)
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Supply-chain guard: ignore freshly published versions for a week so a
+    # compromised release is not picked up on day zero.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      cargo:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  # Python tooling used by CI and the dev environment
+  - package-ecosystem: uv
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Supply-chain guard: ignore freshly published versions for a week so a
+    # compromised release is not picked up on day zero.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      python:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  # Keeps the SHA pins in .github/workflows/ current
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Supply-chain guard: ignore freshly published versions for a week so a
+    # compromised release is not picked up on day zero.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -54,6 +54,39 @@ jobs:
       # file-hygiene, typos, taplo, actionlint and zizmor hooks.
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
+  cargo-deny:
+    name: "cargo deny"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          command: check advisories bans licenses sources
+
+  pip-audit:
+    name: "pip audit"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          # This workflow still contains the publishing job, so caching here
+          # would be a cache-poisoning vector.
+          enable-cache: false
+
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+
+      - run: just audit-py
+
   tests:
     uses: ./.github/workflows/tests.yaml
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,32 @@
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+yanked = "deny"
+
+[licenses]
+version = 2
+# Derived from the licenses actually present in the dependency tree.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
+]
+confidence-threshold = 0.9
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+# `pyo3` is the only path to the CPython ABI; a second copy would be a bug.
+deny = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/justfile
+++ b/justfile
@@ -8,6 +8,18 @@ lint-rust:
 
 lint: lint-py lint-rust
 
+# Supply-chain audits (same checks CI runs)
+deny:
+    cargo deny check advisories bans licenses sources
+
+# `uv export` already pins every transitive dependency, so --no-deps keeps
+# pip-audit from building an isolated resolution environment.
+audit-py:
+    uv export --no-emit-project --all-groups --format requirements-txt > /tmp/moka-py-requirements.txt
+    uvx pip-audit --strict --no-deps --disable-pip --requirement /tmp/moka-py-requirements.txt
+
+audit: deny audit-py
+
 clippy: lint
 
 fmt-py:

--- a/tests/test_per_entry_expiry.py
+++ b/tests/test_per_entry_expiry.py
@@ -117,15 +117,15 @@ async def test_different_entries_different_ttls():
         # second TTL shorter, re-set before expiry
         ({"ttl": 0.8}, {"ttl": 0.2}, 0.2, 0.1, 0.3),
         # first TTL, second switches to TTI, re-set before expiry
-        ({"ttl": 0.3}, {"tti": 0.2}, 0.2, 0.1, 0.3),
+        ({"ttl": 0.3}, {"tti": 0.2}, 0.2, 0.1, 0.4),
         # first TTL, second switches to TTL+TTI, re-set before expiry
-        ({"ttl": 0.3}, {"ttl": 0.8, "tti": 0.2}, 0.2, 0.1, 0.3),
+        ({"ttl": 0.3}, {"ttl": 0.8, "tti": 0.2}, 0.2, 0.1, 0.4),
         # second TTL same as first, re-set AFTER first expired
         ({"ttl": 0.2}, {"ttl": 0.3}, 0.3, 0.2, 0.4),
         # second TTL shorter, re-set AFTER first expired
         ({"ttl": 0.2}, {"ttl": 0.15}, 0.3, 0.1, 0.2),
         # first TTL, second switches to TTI, re-set AFTER first expired
-        ({"ttl": 0.2}, {"tti": 0.2}, 0.3, 0.1, 0.3),
+        ({"ttl": 0.2}, {"tti": 0.2}, 0.3, 0.1, 0.4),
     ],
     ids=[
         "same_ttl_before_expiry",
@@ -151,6 +151,8 @@ async def test_re_set_resets_deadline(
     await asyncio.sleep(alive_after_re_set)
     assert cache.get("k") == "v2", "entry should still be alive"
 
+    # NB: the "still alive" get above re-bumps TTI, so for the tti cases this
+    # remaining sleep must exceed the TTI rather than equal it exactly.
     await asyncio.sleep(dead_after_re_set - alive_after_re_set)
     assert cache.get("k") is None, "entry should have expired"
 


### PR DESCRIPTION
Third of four split out of #18. **Stacked on #20.**

## What it adds

| Check | Scope |
| --- | --- |
| `cargo-deny` | advisories, bans, licenses, sources — the Rust code that actually ships |
| `pip-audit` | the exported uv lockfile (dev/CI tooling) |
| Dependabot | cargo, uv, github-actions — weekly, grouped, 7-day cooldown |

Both audits are also `just` recipes (`just deny`, `just audit-py`,
`just audit`) so they run locally exactly as CI runs them.

## Verified by actually running them

```
$ cargo deny check advisories bans licenses sources
advisories ok, bans ok, licenses ok, sources ok

$ just audit-py
No known vulnerabilities found          # 44 packages
```

The license allow-list is derived from the licenses actually present in the
dependency tree (`cargo metadata`), not guessed. Duplicate crate versions
(`r-efi` 5/6 via two `getrandom` majors) are reported as warnings rather
than failing the build.

`pip-audit` runs with `--no-deps --disable-pip`: `uv export` already pins
every transitive dependency, so building an isolated resolution environment
adds nothing — and it crashes on `ensurepip` with uv-managed interpreters.

## Dependabot cooldown

zizmor's `dependabot-cooldown` audit flagged the initial config: without a
cooldown, Dependabot proposes a version the day it is published, which is
exactly the window in which a compromised release is still undetected. All
three ecosystems now wait 7 days.