### PR TITLE
ci: unblock dependabot PRs (codecov token, flaky README example)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -84,6 +84,12 @@ jobs:
     name: "coverage"
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      # Dependabot PRs run against the Dependabot secret store, which does not
+      # carry CODECOV_TOKEN. Compute the flag here (job-level env is visible to
+      # a step's own `if:`, step-level env is not) and skip the upload rather
+      # than failing the whole run.
+      HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -112,12 +118,17 @@ jobs:
         run: pytest tests/ --ignore=tests/test_benches.py --ignore=tests/test_wasm.py --cov --cov-report=xml
 
       - name: "Upload coverage to Codecov"
+        if: env.HAS_CODECOV_TOKEN == 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage.xml
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: "Skipped coverage upload (no CODECOV_TOKEN)"
+        if: env.HAS_CODECOV_TOKEN != 'true'
+        run: echo "::notice::CODECOV_TOKEN is not available to this run; coverage was measured but not uploaded."
 
   tests:
     uses: ./.github/workflows/tests.yaml

--- a/README.md
+++ b/README.md
@@ -354,11 +354,15 @@ events: list[tuple[str, list[int], str]] = []
 moka: Moka[str, list[int]] = Moka(2, eviction_listener=key_evicted, ttl=0.5)
 moka.set("hello", [1, 2, 3])
 moka.set("hello", [3, 2, 1])  # replaced
-moka.set("foo", [4])  # expired
-moka.set("baz", "size")
+moka.set("foo", [4])
 moka.remove("foo")  # explicit
+for i in range(10):
+    moka.set(f"overflow-{i}", [i])  # over capacity, so most of these go away with "size"
+
+# Maintenance is lazy, so ask for it explicitly instead of guessing when it happens
+moka.run_pending_tasks()
 sleep(1.0)
-moka.get("anything")  # this will trigger eviction for expired
+moka.run_pending_tasks()  # whatever survived is past its TTL by now: "expired"
 
 causes = {c for _, _, c in events}
 assert causes == {"size", "expired", "replaced", "explicit"}, events


### PR DESCRIPTION
All three open dependabot PRs (#27, #28, #29) were red. Two independent causes:

**1. `coverage` failed on every dependabot PR.** Those runs use the Dependabot
secret store, which does not carry `CODECOV_TOKEN`, so the uploader ran with
`Token length: 0` and codecov rejected the upload. `fail_ci_if_error: true`
turned that into a job failure and took the `CI ok` gate with it.

The upload is now guarded by a job-level `HAS_CODECOV_TOKEN` flag (job-level
env is visible to a step's own `if:`; step-level env is not). Coverage is still
measured on those runs — only the upload is skipped, with a notice annotation.

If you'd rather have real coverage on dependabot PRs, mirror the secret into the
Dependabot store: `gh secret set CODECOV_TOKEN --app dependabot`.

**2. The eviction-listener README example was flaky**, which is what broke #27
(moka 0.12.15 -> 0.12.16). It filled a capacity-2 cache with three keys and then
removed one, so a `"size"` eviction was never guaranteed. It only passed because
0.12.15 leaked a phantom entry slot per insert/remove race, effectively shrinking
the capacity; [0.12.16 fixes that leak](https://github.com/moka-rs/moka/blob/main/CHANGELOG.md).
The example now overflows the cache well past capacity and drives maintenance
with `run_pending_tasks()`. Verified deterministic against both 0.12.15 and
0.12.16 locally.